### PR TITLE
Add GTM to podspec.

### DIFF
--- a/iConsole.podspec
+++ b/iConsole.podspec
@@ -6,7 +6,8 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/nicklockwood/iConsole'
   s.authors  = 'Nick Lockwood'
   s.source   = { :git => 'https://github.com/nicklockwood/iConsole.git', :tag => '1.5.2' }
-  s.source_files = 'iConsole'
+  s.source_files = 'iConsole', 'GTM'
   s.requires_arc = true
   s.ios.deployment_target = '4.3'
 end
+


### PR DESCRIPTION
Sorry for my English.

I'm developing app with iConsole.
I got compiling error, Xcode puts "'GTMStackTrace.h' file not found".
Cause maybe the current podspec file is not included GTM.
I think about this issue, Pod needs GTM via podspec file.
